### PR TITLE
Escape angle brackets

### DIFF
--- a/lib/ex_twiml.ex
+++ b/lib/ex_twiml.ex
@@ -152,7 +152,7 @@ defmodule ExTwiml do
   """
   defmacro text(string) do
     quote do
-      put_buffer var!(buffer, Twiml), to_string(unquote(string))
+      put_buffer var!(buffer, Twiml), escape_text(to_string(unquote(string)))
     end
   end
 
@@ -191,7 +191,7 @@ defmodule ExTwiml do
   # {:text, [], ["Hello World"]}
   defp postwalk({:text, _meta, [string]}) do
     # Just add the text to the buffer. Nothing else needed.
-    quote do: put_buffer(var!(buffer, Twiml), to_string(unquote(string)))
+    quote do: text unquote(string)
   end
 
   # {:gather, [], [[do: inner]]}

--- a/lib/ex_twiml/utilities.ex
+++ b/lib/ex_twiml/utilities.ex
@@ -129,5 +129,7 @@ defmodule ExTwiml.Utilities do
     |> replace("&", "&amp;")
     |> replace("<", "&lt;")
     |> replace(">", "&gt;")
+    |> replace("\"", "&quot;")
+    |> replace("'", "&apos;")
   end
 end

--- a/lib/ex_twiml/utilities.ex
+++ b/lib/ex_twiml/utilities.ex
@@ -3,7 +3,7 @@ defmodule ExTwiml.Utilities do
   A grab bag of helpful functions used to generate XML.
   """
 
-  import String, only: [downcase: 1]
+  import String, only: [downcase: 1, replace: 3]
 
   @doc """
   Generates an XML tag.
@@ -72,7 +72,7 @@ defmodule ExTwiml.Utilities do
   def xml_attributes(attrs) do
     for {key, val} <- attrs,
         into: "",
-        do: " #{camelize(key)}=\"#{val}\""
+        do: " #{camelize(key)}=\"#{escape_attr(to_string(val))}\""
   end
 
   @doc """
@@ -100,5 +100,34 @@ defmodule ExTwiml.Utilities do
 
   defp do_camelize([first, rest], _) do
     downcase(first) <> Mix.Utils.camelize(rest)
+  end
+
+  @doc """
+  escape special characters in XML attributes
+
+  Note: we must to escape only "&" and "<",
+  but, its common to escape more special characters
+  """
+  @spec escape_attr(String.t) :: String.t
+  def escape_attr(string) do
+    string
+    |> replace("&", "&amp;")
+    |> replace("<", "&lt;")
+    |> replace(">", "&gt;")
+    |> replace("\"", "&quot;")
+    |> replace("'", "&apos;")
+    |> replace("\x0d", "&#xd;")
+    |> replace("\x0a", "&#xa;")
+  end
+
+  @doc """
+  escape special characters in XML text
+  """
+  @spec escape_text(String.t) :: String.t
+  def escape_text(string) do
+    string
+    |> replace("&", "&amp;")
+    |> replace("<", "&lt;")
+    |> replace(">", "&gt;")
   end
 end

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -123,7 +123,7 @@ defmodule ExTwimlTest do
       task ~s({"selected_language": "it"})
     end
 
-    assert_twiml markup, ~s(<Task>{"selected_language": "it"}</Task>)
+    assert_twiml markup, ~s(<Task>{&quot;selected_language&quot;: &quot;it&quot;}</Task>)
   end
 
   test "can render the <Task> verb nested inside an <Enqueue> verb" do
@@ -133,7 +133,7 @@ defmodule ExTwimlTest do
       end
     end
 
-    assert_twiml markup, ~s(<Enqueue><Task>{"selected_language": "it"}</Task></Enqueue>)
+    assert_twiml markup, ~s(<Enqueue><Task>{&quot;selected_language&quot;: &quot;it&quot;}</Task></Enqueue>)
   end
 
   test "can render the <Leave> verb" do
@@ -253,7 +253,7 @@ defmodule ExTwimlTest do
       say "I'm Alice", options
     end
 
-    assert_twiml markup, "<Say voice=\"alice\">I'm Alice</Say>"
+    assert_twiml markup, "<Say voice=\"alice\">I&apos;m Alice</Say>"
   end
 
   test ".twiml self-closing verbs can take options as a variable" do

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -290,6 +290,31 @@ defmodule ExTwimlTest do
       Macro.expand(ast, __ENV__)
     end
   end
+  test "escape message body" do
+    markup = twiml do
+      message do
+        body "hello :<"
+      end
+    end
+
+    assert_twiml markup, "<Message><Body>hello :&lt;</Body></Message>"
+  end
+
+  test "escape simple text" do
+    markup = twiml do
+        text "hello :<"
+    end
+
+    assert_twiml markup, "hello :&lt;"
+  end
+
+  test "escape attribute" do
+    markup = twiml do
+      tag :mms, to: "112345'" do text "hello" end
+    end
+
+    assert_twiml markup, "<Mms to=\"112345&apos;\">hello</Mms>"
+  end
 
   defp assert_twiml(lhs, rhs) do
     assert lhs == "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response>#{rhs}</Response>"


### PR DESCRIPTION
The baseline python library does.  It seems appropriate for the Elixir client to do so as well.